### PR TITLE
Fix memory leak in device destructor

### DIFF
--- a/src/device.cc
+++ b/src/device.cc
@@ -47,8 +47,19 @@ class HackWorker : public Nan::AsyncWorker {
   uint64_t arg;
 };
 
-Device::Device() {};
-Device::~Device() {};
+Device::Device()
+  : onRx(NULL), onTx(NULL) {};
+
+Device::~Device() {
+  if (onRx) {
+    delete onRx;
+    onRx = NULL;
+  }
+  if (onTx) {
+    delete onTx;
+    onTx = NULL;
+  }
+};
 
 Nan::Persistent<Function> Device::constructor;
 


### PR DESCRIPTION
## Summary
- release asynchronous callback objects when a Device instance is destroyed

## Testing
- `npm test` *(fails: Missing script)*
- `npm install --ignore-scripts` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68534c7ccc2c8331b2eaa9c6cddc0d88