### PR TITLE
Add tests for parse utility

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,20 +1,5 @@
 #!/usr/bin/env node
 
-var minimist = require('minimist')
-var argv = minimist(process.argv.slice(2))
-var hackrf = require('./')
-
-var devices = hackrf()
-console.log('Found %d HackRF devices', devices.length)
-if (devices.length === 0) throw new Error('No devices connected')
-var d = devices.open(0)
-
-var pulse = 0
-var low = Infinity
-var high = 0
-
-console.log('HackRF version is %s', d.getVersion())
-
 function parse (f) {
   if (typeof f === 'number') return f
   f = f.replace(/M/i, '* 1000000')
@@ -22,6 +7,24 @@ function parse (f) {
   f = f.replace(/hz/, '')
   return eval('(' + f + ')') // yolo
 }
+
+module.exports.parse = parse
+
+if (require.main === module) {
+  var minimist = require('minimist')
+  var argv = minimist(process.argv.slice(2))
+  var hackrf = require('./')
+
+  var devices = hackrf()
+  console.log('Found %d HackRF devices', devices.length)
+  if (devices.length === 0) throw new Error('No devices connected')
+  var d = devices.open(0)
+
+  var pulse = 0
+  var low = Infinity
+  var high = 0
+
+  console.log('HackRF version is %s', d.getVersion())
 
 if (argv.frequency) d.setFrequency(parse(argv.frequency))
 if (argv.bandwidth) d.setBandwidth(parse(argv.bandwidth))
@@ -73,4 +76,5 @@ if (argv.starttx) {
       else console.log('Idling...')
     }, 200)
   }
+}
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "install": "node-gyp-build",
     "prebuild": "prebuildify -a",
-    "prebuild-ia32": "prebuildify -a --arch ia32"
+    "prebuild-ia32": "prebuildify -a --arch ia32",
+    "test": "node test/parse.js"
   },
   "repository": {
     "type": "git",

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,0 +1,8 @@
+const assert = require('assert')
+const parse = require('../bin.js').parse
+
+assert.strictEqual(parse('10Mhz'), 10 * 1e6)
+assert.strictEqual(parse('100khz'), 100 * 1e3)
+assert.strictEqual(parse(500), 500)
+
+console.log('parse tests passed')


### PR DESCRIPTION
## Summary
- export `parse` helper from `bin.js`
- avoid running CLI code on require
- add simple unit test for `parse`
- wire `npm test` to run the new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68534e07184483318390e7156fa6738e